### PR TITLE
Update blocklistConfig.json with CPBL hosts

### DIFF
--- a/blocklistConfig.json
+++ b/blocklistConfig.json
@@ -1224,6 +1224,13 @@
       "group": "privacy",
       "subg": "services",
       "url": "https://raw.githubusercontent.com/ftpmorph/ftprivacy/master/blocklists/hola-luminati-full-block.txt"
+     },
+     {
+      "vname": "CPBL Final (bongochong)",
+      "format": "hosts",
+      "group": "security",
+      "subg": "piracy",
+      "url": "https://raw.githubusercontent.com/bongochong/CombinedPrivacyBlockLists/master/newhosts-final.hosts"
     }
   ]
 }

--- a/blocklistConfig.json
+++ b/blocklistConfig.json
@@ -1226,10 +1226,10 @@
       "url": "https://raw.githubusercontent.com/ftpmorph/ftprivacy/master/blocklists/hola-luminati-full-block.txt"
      },
      {
-      "vname": "CPBL Final (bongochong)",
+      "vname": "Combined Privacy BlockLists: Final (bongochong)",
       "format": "hosts",
-      "group": "security",
-      "subg": "piracy",
+      "group": "privacy",
+      "subg": "",
       "url": "https://raw.githubusercontent.com/bongochong/CombinedPrivacyBlockLists/master/newhosts-final.hosts"
     }
   ]


### PR DESCRIPTION
**Host link:** https://raw.githubusercontent.com/bongochong/CombinedPrivacyBlockLists/master/newhosts-final.hosts
**Source:** [CombinedPrivacyBlockLists](https://github.com/bongochong/CombinedPrivacyBlockLists) by @bongochong
**License:** [CPAL-1.0](https://github.com/bongochong/CombinedPrivacyBlockLists/blob/master/LICENSE)
**Description:** Ad & malware-blocking hosts files, IP blocklists, PAC filters, and ABP / uBO subscriptions, all merged, sorted and de-duped from multiple reputable sources, along with bongochong's own research. It block malicious and harmfully deceptive content, like advertising, tracking, telemetry, scam, and malware servers. The lists **do not** block porn, social media, or so-called "fake news" domains, except for the advertising, tracking, telemetry, scam, and malware servers associated with such sites. False positives are rigorously removed from all lists upon discovery, and the hosts files are processed by an IDN-to-Punycode conversion routine (meaning that they can be utilized on all operating systems)