### PR TITLE
Update blocklistConfig.json with AMP Hosts

### DIFF
--- a/blocklistConfig.json
+++ b/blocklistConfig.json
@@ -1224,13 +1224,20 @@
       "group": "privacy",
       "subg": "services",
       "url": "https://raw.githubusercontent.com/ftpmorph/ftprivacy/master/blocklists/hola-luminati-full-block.txt"
-     },
-     {
+    },
+    {
       "vname": "Combined Privacy BlockLists: Final (bongochong)",
       "format": "hosts",
       "group": "privacy",
       "subg": "",
       "url": "https://raw.githubusercontent.com/bongochong/CombinedPrivacyBlockLists/master/newhosts-final.hosts"
+    },
+    {
+      "vname": "Google AMP (developerdan)",
+      "format": "hosts",
+      "group": "privacy",
+      "subg": "",
+      "url": "https://www.github.developerdan.com/hosts/lists/amp-hosts-extended.txt"
     }
   ]
 }


### PR DESCRIPTION
**Host list**: https://www.github.developerdan.com/hosts/lists/amp-hosts-extended.txt
**Source**: https://www.github.developerdan.com/hosts/
**Github page**: https://github.com/lightswitch05/hosts by @lightswitch05
**License**: [Apache-2.0](https://github.com/lightswitch05/hosts/blob/master/LICENSE)
**Description**: [Google's Accelerated Mobile Pages (AMP)](https://www.theregister.co.uk/2017/05/19/open_source_insider_google_amp_bad_bad_bad/) are taking over the web. Block AMP pages with this list.