### PR TITLE
Update blocklistConfig.json with Developerdan's ads & tracking Hosts

### DIFF
--- a/blocklistConfig.json
+++ b/blocklistConfig.json
@@ -1224,13 +1224,20 @@
       "group": "privacy",
       "subg": "services",
       "url": "https://raw.githubusercontent.com/ftpmorph/ftprivacy/master/blocklists/hola-luminati-full-block.txt"
-     },
-     {
+    },
+    {
       "vname": "Combined Privacy Block Lists: Final (bongochong)",
       "format": "hosts",
       "group": "privacy",
       "subg": "notracking",
       "url": "https://raw.githubusercontent.com/bongochong/CombinedPrivacyBlockLists/master/newhosts-final.hosts"
+    },
+    {
+      "vname": "Developerdan's Hosts (ads & tracking)",
+      "format": "hosts",
+      "group": "privacy",
+      "subg": "",
+      "url": "https://www.github.developerdan.com/hosts/lists/ads-and-tracking-extended.txt"
     }
   ]
 }


### PR DESCRIPTION
**Host list:** https://www.github.developerdan.com/hosts/lists/ads-and-tracking-extended.txt
**Source:** https://www.github.developerdan.com/hosts/
**Github page:** https://github.com/lightswitch05/hosts by @lightswitch05
**License:** [Apache-2.0](https://github.com/lightswitch05/hosts/blob/master/LICENSE)
**Description:** A programmatically expanded list of hosts used for advertisements and tracking.