### PR TITLE
Addition of Light/Mini Variant of my Hosts File

### DIFF
--- a/blocklistConfig.json
+++ b/blocklistConfig.json
@@ -1401,11 +1401,19 @@
       "pack": []
     },
     {
-      "vname": "Combined Privacy Block Lists: Final (bongochong)",
+      "vname": "Combined Privacy Block Lists: Full (bongochong)",
       "format": "hosts",
       "group": "privacy",
       "subg": "notracking",
       "url": "https://raw.githubusercontent.com/bongochong/CombinedPrivacyBlockLists/master/newhosts-final.hosts",
+      "pack": []
+    },
+    {
+      "vname": "Combined Privacy Block Lists: Light (bongochong)",
+      "format": "hosts",
+      "group": "privacy",
+      "subg": "notracking",
+      "url": "https://raw.githubusercontent.com/bongochong/CombinedPrivacyBlockLists/master/MiniLists/mini-newhosts.hosts",
       "pack": []
     },
     {


### PR DESCRIPTION
I hope this is OK, but it would be neat to have the less aggressive variant of my hosts file available through rethink. It's a little bit less aggressive and useful as a list for smart TVs and similar devices which require extra leniency. I have differentiated between the two lists in blocklistConfig.json as well.