### PR TITLE
Add PersianBlocker list

### DIFF
--- a/blocklistConfig.json
+++ b/blocklistConfig.json
@@ -1535,6 +1535,14 @@
         "subg": "",
         "url": "https://raw.githubusercontent.com/PeterDaveHello/url-shorteners/master/list",
         "pack": []
-    }
+    },
+    {
+        "vname": "Persian Blocker",
+        "format": "domains",
+        "group": "privacy",
+        "subg": "",
+        "url": "https://raw.githubusercontent.com/MasterKia/PersianBlocker/main/PersianBlockerHosts.txt",
+        "pack": []
+    }    
   ]
 }


### PR DESCRIPTION
Used "**Persian Blocker**" instead of "PersianBlocker" to _hopefully_ [resolve ambiguity](https://github.com/celzero/rethink-app/issues/569#issuecomment-1252449075) as mentioned by @ignoramous.
(So users will perceive it "Persian _ad/tracker_ Blocker")

By the way the README instructions lack the `"pack": []` part.