### PR TITLE
Add Game Console Adblock List

### DIFF
--- a/config.json
+++ b/config.json
@@ -1545,6 +1545,14 @@
       "subg": "The Block List Project",
       "url": "https://blocklistproject.github.io/Lists/porn.txt",
       "pack": ["adult"]
+    },
+    {
+      "vname": "Game Console Adblock List",
+      "format": "domains",
+      "group": "Privacy",
+      "subg": "",
+      "url": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/GameConsoleAdblockList.txt",
+      "pack": []
     }
   ]
 }

--- a/config.json
+++ b/config.json
@@ -1547,7 +1547,7 @@
       "pack": ["adult"]
     },
     {
-      "vname": "Game Console Adblock List",
+      "vname": "Game Console Adblock List (Dandelion Sprout)",
       "format": "domains",
       "group": "Privacy",
       "subg": "",


### PR DESCRIPTION
A very tiny list that is included in adguards private dns service but not included here. Might be useful to a few people