### PR TITLE
Add ShadowWhisperer Malware & Typo Squatting Lists

### DIFF
--- a/config.json
+++ b/config.json
@@ -1569,6 +1569,22 @@
       "subg": "The Block List Project",
       "url": "https://blocklistproject.github.io/Lists/tracking.txt",
       "pack": ["spyware"]
+    },
+    {
+      "vname": "Malware (ShadowWhisperer)",
+      "format": "domains",
+      "group": "Security",
+      "subg": "ShadowWhisperer",
+      "url": "https://raw.githubusercontent.com/ShadowWhisperer/BlockLists/master/Lists/Malware",
+      "pack": ["malware"]
+    },
+    {
+      "vname": "Typo (ShadowWhisperer)",
+      "format": "domains",
+      "group": "Security",
+      "subg": "ShadowWhisperer",
+      "url": "https://raw.githubusercontent.com/ShadowWhisperer/BlockLists/master/Lists/Typo",
+      "pack": ["scams & phishing"]
     }
   ]
 }


### PR DESCRIPTION
I feel like the typo squatting list is a must and why not have a bit better malware protection on the side. Malware list has 31,358 domains and typo squatting has 73,232. These lists are not included in any other lists on rethinkdns from my knowledge and these lists do not include any other lists in them. There are plenty of other lists by ShadowWhisperer that may be of interest at https://github.com/ShadowWhisperer/BlockLists/tree/master/Lists . These were just the ones I thought would be suited best