### PR TITLE
Switch Badd Boyz Hosts to Domains & Clean

### DIFF
--- a/config.json
+++ b/config.json
@@ -526,10 +526,10 @@
     },
     {
       "vname": "Badd Boyz Hosts (Mitchell Krogza)",
-      "format": "hosts",
+      "format": "domains",
       "group": "Security",
       "subg": "BaddBoyz",
-      "url": "https://raw.githubusercontent.com/mitchellkrogza/Badd-Boyz-Hosts/master/hosts",
+      "url": "https://raw.githubusercontent.com/Ultimate-Hosts-Blacklist/BaddBoyzHosts/master/clean.list",
       "pack": ["malware", "adult"]
     },
     {


### PR DESCRIPTION
So badd boyz host was last updated 6 months ago and with that, some URLs may be broken. Ultimate host blacklist tries to remove those and thus saving about 100 domains here. Also switched it to domains from hosts. More info at the github https://github.com/Ultimate-Hosts-Blacklist/BaddBoyzHosts