### PR TITLE
Add windowsspyblocker extra to Windows Telemetry and more

### DIFF
--- a/config.json
+++ b/config.json
@@ -1298,10 +1298,10 @@
     {
       "vname": "Windows Telemetry",
       "group": "Privacy",
-      "subg": "RPiList",
-      "format": ["hosts", "domains"],
-      "url": ["https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/hosts/spy.txt",
-              "https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Win10Telemetry"],
+      "subg": "WindowsSpyBlocker",
+      "format": ["wildcard", "wildcard"],
+      "url": ["https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/dnscrypt/spy.txt",
+              "https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/dnscrypt/extra.txt"],
       "pack": ["windows"]
     },
     {

--- a/config.json
+++ b/config.json
@@ -1299,9 +1299,10 @@
       "vname": "Windows Telemetry",
       "group": "Privacy",
       "subg": "WindowsSpyBlocker",
-      "format": ["wildcard", "wildcard"],
+      "format": ["wildcard", "wildcard", "domains"],
       "url": ["https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/dnscrypt/spy.txt",
-              "https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/dnscrypt/extra.txt"],
+              "https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/dnscrypt/extra.txt"
+              "https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Win10Telemetry"],
       "pack": ["windows"]
     },
     {

--- a/config.json
+++ b/config.json
@@ -1301,7 +1301,7 @@
       "subg": "WindowsSpyBlocker",
       "format": ["wildcard", "wildcard", "domains"],
       "url": ["https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/dnscrypt/spy.txt",
-              "https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/dnscrypt/extra.txt"
+              "https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/dnscrypt/extra.txt",
               "https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/Win10Telemetry"],
       "pack": ["windows"]
     },


### PR DESCRIPTION
Changes the original Windows Spy Blocker list to wildcard domains and replace rpilist version with windows spy blocker extra. Would be a bit more effective I believe