### PR TITLE
Use blockada optimized version

### DIFF
--- a/config.json
+++ b/config.json
@@ -1774,8 +1774,8 @@
       "vname": "Yet another small uBlock filter list",
       "group": "Privacy",
       "subg": "",
-      "format": "hosts",
-      "url": "https://raw.githubusercontent.com/mtxadmin/ublock/master/hosts.txt",
+      "format": "wildcard",
+      "url": "https://raw.githubusercontent.com/mtxadmin/ublock/master/hosts_blokada.txt",
       "pack": ["extremeprivacy"],
       "level": [2]
     },


### PR DESCRIPTION
Reduces # of entries by a lot. Potentially leaving room for other blocklists to be added to the service in the future. Although not important. Reduces entries by a little less then 90% i believe

Another thing is that I personally do not use the ublock filter list as I find it too aggressive and broke twitter last time I used the list so I do not use it. I wonder if the optimized version is less aggressive.