### PR TITLE
Add Nextdns Disguised Third-Party Tracker List

### DIFF
--- a/config.json
+++ b/config.json
@@ -841,10 +841,11 @@
     },
     {
       "vname": "AdGuard DNS filters",
-      "format": "abp",
+      "format": "abp, domains",
       "group": "Privacy",
       "subg": "",
-      "url": "https://adguardteam.github.io/AdGuardSDNSFilter/Filters/filter.txt",
+      "url": ["https://adguardteam.github.io/AdGuardSDNSFilter/Filters/filter.txt",
+              https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/combined_disguised_trackers_justdomains.txt"],
       "pack": ["liteprivacy"]
     },
     {
@@ -1569,14 +1570,6 @@
       "subg": "The Block List Project",
       "url": "https://blocklistproject.github.io/Lists/alt-version/tracking-nl.txt",
       "pack": ["spyware"]
-    },
-    {
-      "vname": "Disguised Third-Party Trackers (NextDNS)",
-      "format": "domains",
-      "group": "Privacy",
-      "subg": "TrackingDomains",
-      "url": "https://raw.githubusercontent.com/nextdns/cname-cloaking-blocklist/master/domains",
-      "pack": []
     }
   ]
 }

--- a/config.json
+++ b/config.json
@@ -845,7 +845,7 @@
       "group": "Privacy",
       "subg": "",
       "url": ["https://adguardteam.github.io/AdGuardSDNSFilter/Filters/filter.txt",
-              https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/combined_disguised_trackers_justdomains.txt"],
+              "https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/combined_disguised_trackers_justdomains.txt"],
       "pack": ["liteprivacy"]
     },
     {

--- a/config.json
+++ b/config.json
@@ -1569,6 +1569,14 @@
       "subg": "The Block List Project",
       "url": "https://blocklistproject.github.io/Lists/alt-version/tracking-nl.txt",
       "pack": ["spyware"]
+    },
+    {
+      "vname": "Disguised Third-Party Trackers (NextDNS)",
+      "format": "domains",
+      "group": "Privacy",
+      "subg": "TrackingDomains",
+      "url": "https://raw.githubusercontent.com/nextdns/cname-cloaking-blocklist/master/domains",
+      "pack": []
     }
   ]
 }


### PR DESCRIPTION
A small list that is included with nextdns and it should be included here in my opinion