### PR TITLE
Add Hagezi Multi Ultimate

### DIFF
--- a/config.json
+++ b/config.json
@@ -1569,6 +1569,14 @@
       "subg": "The Block List Project",
       "url": "https://blocklistproject.github.io/Lists/alt-version/tracking-nl.txt",
       "pack": ["spyware"]
+    },
+    {
+      "vname": "Multi Ultimate (Hagezi)",
+      "format": "wildcard",
+      "group": "Privacy",
+      "subg": "Hagezi",
+      "url": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/ultimate.txt",
+      "pack": ["extremeprivacy"]
     }
   ]
 }


### PR DESCRIPTION
The newly added Multi Ultimate includes both pro++ and threat intelligence and then builds off of those for a more aggressive version of pro++