### PR TITLE
Add LostAd DNS list

### DIFF
--- a/config.json
+++ b/config.json
@@ -1798,6 +1798,15 @@
       "url": "https://raw.githubusercontent.com/ShadowWhisperer/BlockLists/master/Lists/Microsoft",
       "pack": ["microsoft"],
       "level": [2]
+    },
+    {
+      "vname": "LostAd (DNS)",
+      "group": "Privacy",
+      "subg": "",
+      "format": "abp",
+      "url": "https://raw.githubusercontent.com/lennihein/LostAd/main/lostad_dns.txt",
+      "pack": ["aggressiveprivacy"],
+      "level": [1]
     }
   ]
 }


### PR DESCRIPTION
Curated from multiple sources which some are included already and some are not. You can see the sources here.  https://github.com/lennihein/LostAd/blob/main/lostad_dns.json .