### PR TITLE
Minor blocklist link changes

### DIFF
--- a/config.json
+++ b/config.json
@@ -916,7 +916,7 @@
       "level": [0]
     },
     {
-      "vname": "1Hosts (Mini)",
+      "vname": "1Hosts (mini)",
       "group": "Privacy",
       "subg": "1Hosts",
       "format": "domains",

--- a/config.json
+++ b/config.json
@@ -1420,7 +1420,7 @@
       "group": "Privacy",
       "subg": "Quidsup",
       "format": "domains",
-      "url": "https://gitlab.com/quidsup/notrack-blocklists/raw/master/notrack-blocklist.txt",
+      "url": "https://gitlab.com/quidsup/notrack-blocklists/-/raw/master/trackers.list",
       "pack": ["aggressiveprivacy", "spyware"],
       "level": [1, 1]
     },
@@ -1483,7 +1483,7 @@
       "group": "Privacy",
       "subg": "",
       "format": "hosts",
-      "url": "https://someonewhocares.org/hosts/hosts",
+      "url": "https://someonewhocares.org/hosts/zero/hosts",
       "pack": ["liteprivacy"],
       "level": [0]
     },


### PR DESCRIPTION
These changes are extremely tiny and are only for changing to 0.0.0.0 from 127.0.0.1 for someonewhocares.org and removing the # adware (for example) next to each entry in the no track list