### PR TITLE
Mark Adult (Mahadi Xion) dead until a replacement can be found

### DIFF
--- a/config.json
+++ b/config.json
@@ -171,7 +171,7 @@
       "subg": "",
       "format": "hosts",
       "url": "https://raw.githubusercontent.com/mhxion/pornaway/master/hosts/porn_sites.txt",
-      "pack": ["adult"],
+      "pack": ["dead"],
       "level": [0]
     },
     {


### PR DESCRIPTION
Hasn’t been updated since august 2018 according to the blocklist and according to the repo, it has only been updated less then 10 times since then and was only for a single domain at a time. I think a replacement should be found but I’m unsure of what to replace it with, at this point in time