### PR TITLE
config.json: typo

### DIFF
--- a/config.json
+++ b/config.json
@@ -1179,7 +1179,7 @@
       "level": [0]
     },
     {
-      "vname": "Multi (Hagezi)",
+      "vname": "Normal (Hagezi)",
       "group": "Privacy",
       "subg": "Hagezi",
       "format": "wildcard",


### PR DESCRIPTION
did not realize it was called normal and not light. Changed it now to fix that typo