### PR TITLE
config: typo and rmv Marco Acorte’s list because redundant

### DIFF
--- a/config.json
+++ b/config.json
@@ -640,11 +640,11 @@
       "vname": "Threat Intelligence Feeds (Hagezi)",
       "group": "Security",
       "subg": "Hagezi",
-      "format": ["wildcard", "hosts", "domains"],
+      "format": ["wildcard", "domains", "hosts"],
       "url": [
         "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/tif.txt",
-        "https://mypdns.org/my-privacy-dns/hosts/-/raw/master/download/phishing.txt",
-        "https://raw.githubusercontent.com/marco-acorte/antispam-it/main/antispam-it.txt"],
+        "https://raw.githubusercontent.com/marco-acorte/antispam-it/main/antispam-it.txt",
+        "https://mypdns.org/my-privacy-dns/hosts/-/raw/master/download/phishing.txt"],
       "pack": ["spam", "malware", "crypto", "scams & phishing"],
       "level": [2, 2, 2]
     },

--- a/config.json
+++ b/config.json
@@ -637,13 +637,12 @@
       "level": [2]
     },
     {
-      "vname": "Threat Intelligence Feeds(Hagezi)",
+      "vname": "Threat Intelligence Feeds (Hagezi)",
       "group": "Security",
       "subg": "Hagezi",
-      "format": ["wildcard", "domains", "hosts"],
+      "format": ["wildcard", "hosts"],
       "url": [
         "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/tif.txt",
-        "https://raw.githubusercontent.com/marco-acorte/antispam-it/main/antispam-it.txt",
         "https://mypdns.org/my-privacy-dns/hosts/-/raw/master/download/phishing.txt"],
       "pack": ["spam", "malware", "crypto", "scams & phishing"],
       "level": [2, 2, 2]
@@ -733,7 +732,7 @@
       "level": [0]
     },
     {
-      "vname": "Bad sites (phishing.mailscanner.info)",
+      "vname": "Bad Sites (phishing.mailscanner.info)",
       "group": "Security",
       "subg": "ThreatIntelligence",
       "format": ["domains", "domains", "hosts"],
@@ -745,7 +744,7 @@
       "level": [2]
     },
     {
-      "vname": "Scam and phishing (infinitytec)",
+      "vname": "Scam and Phishing (infinitytec)",
       "group": "Security",
       "subg": "ThreatIntelligence",
       "format": "domains",
@@ -754,7 +753,7 @@
       "level": [1]
     },
     {
-      "vname": "Ransomware and malware (kriskintel)",
+      "vname": "Ransomware and Malware (kriskintel)",
       "group": "Security",
       "subg": "ThreatIntelligence",
       "format": ["domains", "domains"],
@@ -793,7 +792,7 @@
       "level": [2]
     },
     {
-      "vname": "NSO + others (Amnesty)",
+      "vname": "NSO + Others (Amnesty)",
       "group": "Security",
       "subg": "Amnesty",
       "format": ["domains", "domains", "domains", "hosts"],

--- a/config.json
+++ b/config.json
@@ -1548,8 +1548,8 @@
       "group": "Privacy",
       "subg": "Native",
       "format": ["domains", "wildcard"],
-      "url": "https://raw.githubusercontent.com/nextdns/metadata/master/privacy/native/huawei",
-             "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/native.huawei.txt",
+      "url": ["https://raw.githubusercontent.com/nextdns/metadata/master/privacy/native/huawei",
+             "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/native.huawei.txt"],
       "pack": [],
       "level": []
     },

--- a/config.json
+++ b/config.json
@@ -640,7 +640,7 @@
       "vname": "Threat Intelligence Feeds (Hagezi)",
       "group": "Security",
       "subg": "Hagezi",
-      "format": ["wildcard", "hosts"],
+      "format": ["wildcard", "hosts", "domains"],
       "url": [
         "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/tif.txt",
         "https://mypdns.org/my-privacy-dns/hosts/-/raw/master/download/phishing.txt",

--- a/config.json
+++ b/config.json
@@ -918,7 +918,7 @@
       "subg": "1Hosts",
       "format": "domains",
       "url": "https://raw.githubusercontent.com/badmojr/1Hosts/master/mini/domains.wildcards",
-      "pack": [""],
+      "pack": ["liteprivacy"],
       "level": [0]
     },
     {
@@ -932,11 +932,11 @@
     },
     {
       "vname": "iVoid (intr0)",
-      "group": "Privacy",
-      "subg": "",
+      "group": "Security",
+      "subg": "ThreatIntelligence",
       "format": "hosts",
       "url": "https://gitlab.com/intr0/iVOID.GitLab.io/raw/master/iVOID.hosts",
-      "pack": ["aggressiveprivacy"],
+      "pack": ["scams & phishing"],
       "level": [1]
     },
     {

--- a/config.json
+++ b/config.json
@@ -541,8 +541,8 @@
       "vname": "Malware (UrlHaus.Abuse.Ch)",
       "group": "Security",
       "subg": "ThreatIntelligence",
-      "format": "hosts",
-      "url": "https://malware-filter.gitlab.io/malware-filter/urlhaus-filter-hosts.txt",
+      "format": "domains",
+      "url": "https://malware-filter.gitlab.io/malware-filter/urlhaus-filter-dnscrypt-blocked-names.txt",
       "pack": ["malware"],
       "level": [0]
     },

--- a/config.json
+++ b/config.json
@@ -1061,7 +1061,7 @@
       "vname": "Polish filters (Certyficate.IT)",
       "group": "Privacy",
       "subg": "",
-      "format": "domains",
+      "format": "hosts",
       "url": "https://raw.githubusercontent.com/MajkiIT/polish-ads-filter/master/polish-pihole-filters/hostfile.txt",
       "pack": [],
       "level": []

--- a/config.json
+++ b/config.json
@@ -1593,10 +1593,10 @@
       "vname": "Xiaomi",
       "group": "Privacy",
       "subg": "Native",
-      "format": ["domains", "domains"],
+      "format": ["domains", "wildcard"],
       "url": [
         "https://raw.githubusercontent.com/nextdns/metadata/master/privacy/native/xiaomi",
-        "https://github.com/unknownFalleN/xiaomi-dns-blocklist/blob/master/xiaomi_dns_block.lst"],
+        "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/native.huawei.txt"],
       "pack": [],
       "level": []
     },

--- a/config.json
+++ b/config.json
@@ -643,7 +643,8 @@
       "format": ["wildcard", "hosts"],
       "url": [
         "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/tif.txt",
-        "https://mypdns.org/my-privacy-dns/hosts/-/raw/master/download/phishing.txt"],
+        "https://mypdns.org/my-privacy-dns/hosts/-/raw/master/download/phishing.txt",
+        "https://raw.githubusercontent.com/marco-acorte/antispam-it/main/antispam-it.txt"],
       "pack": ["spam", "malware", "crypto", "scams & phishing"],
       "level": [2, 2, 2]
     },
@@ -1546,8 +1547,9 @@
       "vname": "Huawei",
       "group": "Privacy",
       "subg": "Native",
-      "format": "domains",
+      "format": ["domains", "wildcard"],
       "url": "https://raw.githubusercontent.com/nextdns/metadata/master/privacy/native/huawei",
+             "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/native.huawei.txt",
       "pack": [],
       "level": []
     },
@@ -1593,10 +1595,10 @@
       "vname": "Xiaomi",
       "group": "Privacy",
       "subg": "Native",
-      "format": ["domains", "wildcard"],
+      "format": ["domains", "domains"],
       "url": [
         "https://raw.githubusercontent.com/nextdns/metadata/master/privacy/native/xiaomi",
-        "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/native.huawei.txt"],
+        "https://github.com/unknownFalleN/xiaomi-dns-blocklist/blob/master/xiaomi_dns_block.lst"],
       "pack": [],
       "level": []
     },


### PR DESCRIPTION
Marco Acorte’s list is already included in Hagezi’s threat intelligence so keeping it alongside is redundant