### PR TITLE
Get RedFlagDomains its own entry

### DIFF
--- a/config.json
+++ b/config.json
@@ -746,14 +746,13 @@
       "level": [1]
     },
     {
-      "vname": "Ransomware and Malware (kriskintel)",
+      "vname": "Red Flag Domains",
       "group": "Security",
       "subg": "ThreatIntelligence",
-      "format": ["domains", "domains"],
-      "url": ["https://kriskintel.com/feeds/ktip_malicious_domains.txt",
-              "https://kriskintel.com/feeds/ktip_ransomware_feeds.txt"],
-      "pack": ["scams & phishing"],
-      "level": [0]
+      "format": "domains",
+      "url": "https://dl.red.flag.domains/red.flag.domains.txt",
+      "pack": ["scams & phishing", "spam", "malware"],
+      "level": [0, 0, 0]
     },
     {
       "vname": "Toxic (StopForumSpam + PupFilter)",
@@ -1830,15 +1829,6 @@
       "url": "https://github.com/cbuijs/accomplist/raw/master/tlds/plain.black.domain.list",
       "pack": ["spam"],
       "level": [2]
-    },
-    {
-      "vname": "Red Flag Domains",
-      "group": "Security",
-      "subg": "",
-      "format": "domains",
-      "url": "https://dl.red.flag.domains/red.flag.domains.txt",
-      "pack": ["scams & phishing", "spam", "malware"],
-      "level": [1, 1, 1]
     }
   ]
 }

--- a/config.json
+++ b/config.json
@@ -649,11 +649,8 @@
       "vname": "Malware (RPi)",
       "group": "Security",
       "subg": "RPiList",
-      "format": ["domains", "domains", "domains"],
-      "url": [
-        "https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/malware",
-        "https://dl.red.flag.domains/red.flag.domains.txt",
-        "https://dl.red.flag.domains/red.flag.domains_fr.txt"],
+      "format": "domains",
+      "url": "https://raw.githubusercontent.com/RPiList/specials/master/Blocklisten/malware",
       "pack": ["malware"],
       "level": [1]
     },
@@ -1833,6 +1830,15 @@
       "url": "https://github.com/cbuijs/accomplist/raw/master/tlds/plain.black.domain.list",
       "pack": ["spam"],
       "level": [2]
+    },
+    {
+      "vname": "Red Flag Domains",
+      "group": "Security",
+      "subg": "",
+      "format": "domains",
+      "url": "https://dl.red.flag.domains/red.flag.domains.txt",
+      "pack": ["scams & phishing", "spam", "malware"],
+      "level": [1, 1, 1]
     }
   ]
 }


### PR DESCRIPTION
Changes :
- Remove double DL (the .fr list is integrated in the main link)
- Move RFD into Security category
- Assign correct packs