### PR TITLE
Add hBlock blocklist

### DIFF
--- a/config.json
+++ b/config.json
@@ -1845,6 +1845,15 @@
       "url": "https://github.com/cbuijs/accomplist/raw/master/tlds/plain.black.domain.list",
       "pack": ["spam"],
       "level": [2]
+    },
+    {
+      "vname": "Blocklist (hBlock)",
+      "group": "Privacy",
+      "subg": "",
+      "format": "domains",
+      "url": "https://hblock.molinero.dev/hosts_domains.txt",
+      "pack": ["aggressiveprivacy"],
+      "level": [1]
     }
   ]
 }

--- a/config.json
+++ b/config.json
@@ -1201,13 +1201,13 @@
       "level": [0]
     },
     {
-      "vname": "Energized Blu",
+      "vname": "Blocklist (hBlock)",
       "group": "Privacy",
-      "subg": "Energized",
+      "subg": "",
       "format": "domains",
-      "url": "https://block.energized.pro/blu/formats/domains.txt",
-      "pack": ["dead"],
-      "level": []
+      "url": "https://hblock.molinero.dev/hosts_domains.txt",
+      "pack": ["aggressiveprivacy"],
+      "level": [1]
     },
     {
       "vname": "Energized Regional Extension",
@@ -1845,15 +1845,6 @@
       "url": "https://github.com/cbuijs/accomplist/raw/master/tlds/plain.black.domain.list",
       "pack": ["spam"],
       "level": [2]
-    },
-    {
-      "vname": "Blocklist (hBlock)",
-      "group": "Privacy",
-      "subg": "",
-      "format": "domains",
-      "url": "https://hblock.molinero.dev/hosts_domains.txt",
-      "pack": ["aggressiveprivacy"],
-      "level": [1]
     }
   ]
 }


### PR DESCRIPTION
Found at https://hblock.molinero.dev/ or https://github.com/hectorm/hblock . 

NextDNS just added the blocklist to their lists so why not add it here as well!

Maybe you can find a better fitting name however. I couldn’t think of anything