### PR TITLE
node.dockerfile: capitalize as

### DIFF
--- a/node.Dockerfile
+++ b/node.Dockerfile
@@ -1,4 +1,4 @@
-FROM nikolaik/python-nodejs:latest as runner
+FROM nikolaik/python-nodejs:latest AS runner
 # todo: is git required?
 WORKDIR /app
 COPY . .


### PR DESCRIPTION
The correct way to specify a runner is through AS and not as . I’m unaware of any consequences of using the current way but it helps distinguish from arguments easier when capitalized