### PR TITLE
config: rmv Adguard combined disguised trackers

### DIFF
--- a/config.json
+++ b/config.json
@@ -992,12 +992,11 @@
       "level": []
     },
     {
-      "vname": "AdGuard DNS filters",
+      "vname": "AdGuard SDNS Filter",
       "group": "Privacy",
       "subg": "",
-      "format": ["abp", "domains"],
-      "url": ["https://adguardteam.github.io/AdGuardSDNSFilter/Filters/filter.txt",
-              "https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/combined_disguised_trackers_justdomains.txt"],
+      "format": "abp",
+      "url": "https://adguardteam.github.io/AdGuardSDNSFilter/Filters/filter.txt",
       "pack": ["liteprivacy"],
       "level": [0]
     },


### PR DESCRIPTION
I was doing some thinking and maybe adguard cname blocklist should not be with adguard sdns since there is a higher chance for false positives and you mentioned in the past that serverless dns already uncloaks cnames anyways. So it seems like a good idea to remove this list from sdns