### PR TITLE
Remove AdAway blocklist

### DIFF
--- a/config.json
+++ b/config.json
@@ -964,15 +964,6 @@
       "level": [1]
     },
     {
-      "vname": "AdAway",
-      "group": "Privacy",
-      "subg": "",
-      "format": "hosts",
-      "url": "https://raw.githubusercontent.com/AdAway/adaway.github.io/master/hosts.txt",
-      "pack": ["aggressiveprivacy"],
-      "level": [1]
-    },
-    {
       "vname": "Add.2o7Net",
       "group": "Privacy",
       "subg": "",


### PR DESCRIPTION
List is unmaintained, outdated and borks some sites, fixes #151
