### PR TITLE
Add cbuijs’ Homograph blocklist

### DIFF
--- a/config.json
+++ b/config.json
@@ -1862,6 +1862,15 @@
         "https://raw.githubusercontent.com/tim-hub/tiny-cn-blocklist-replenish/master/others.txt"],
       "pack": ["liteprivacy", "gambling"],
       "level": [0, 1]
+    },
+    {
+      "vname": "Homograph IDN",
+      "group": "Security",
+      "subg": "",
+      "format": "domains",
+      "url": "https://raw.githubusercontent.com/cbuijs/accomplist/master/homograph/plain.black.idn.domain.list",
+      "pack": ["scams & phishing"],
+      "level": [2]
     }
   ]
 }


### PR DESCRIPTION
According to how nextdns puts it. This blocklist would “block domains that impersonate other domains by abusing the large character set made available with the arrival of Internationalized Domain Names (IDNs) — e.g. replacing the Latin letter "e" with the Cyrillic letter "е".”

seems to differ from typosquatting due to one focusing on different characters and the other focusing on spelling something wrong. Eg. gooogle vs gôogle