### PR TITLE
Add Apple Block Certificate Revoke + OTA

### DIFF
--- a/config.json
+++ b/config.json
@@ -1864,7 +1864,7 @@
       "level": [0, 1]
     },
     {
-      "vname": "Apple Block Certificate Revorking + OTA",
+      "vname": "Apple Block Certificate Revoking + OTA",
 
       "group": "ParentalControl",
       "subg": "Apple",

--- a/config.json
+++ b/config.json
@@ -1864,36 +1864,16 @@
       "level": [0, 1]
     },
     {
-      "vname": "fuckfuckadblock (pop-ups & anti-adblock bypass)",
+      "vname": "Apple Block Certificate Revorking + OTA",
 
       "group": "ParentalControl",
-      "subg": "fuckfuckadblock",
+      "subg": "Apple",
 
-      "format": "abp",
-      "URL": [
-        "https://fuckfuckadblock.pages.dev/fuckfuckadblock.txt?_=3",
-        "https://raw.githack.com/bogachenko/fuckfuckadblock/master/fuckfuckadblock.txt?_=3",
-        "https://cdn.statically.io/gh/bogachenko/fuckfuckadblock/master/fuckfuckadblock.txt?_=3",
-        "https://raw.githubusercontent.com/bogachenko/fuckfuckadblock/master/fuckfuckadblock.txt?_=3"],
+      "format": "domains",
+      "URL": "https://raw.githubusercontent.com/Nguyenhuyhoan/Config/main/Adblock_Revoke_Ota.txt",
 
-      "pack": ["recommended", "spam"],
-      "level": [2, 2]
-    },
-    {
-      "vname": "fuckfuckadblock (mining)",
-
-      "group": "ParentalControl",
-      "subg": "fuckfuckadblock",
-
-      "format": "abp",
-      "URL": [
-        "https://fuckfuckadblock.pages.dev/fuckfuckadblock-mining.txt?_=3",
-        "https://raw.githack.com/bogachenko/fuckfuckadblock/master/fuckfuckadblock-mining.txt?_=3",
-        "https://cdn.statically.io/gh/bogachenko/fuckfuckadblock/master/fuckfuckadblock-mining.txt?_=3",
-        "https://raw.githubusercontent.com/bogachenko/fuckfuckadblock/master/fuckfuckadblock-mining.txt?_=3"],
-
-      "pack": ["recommended", "spyware", "malware", "scams & phishing"],
-      "level": [2, 2, 2, 2]
+      "pack": [],
+      "level": []
     }
   ]
 }

--- a/config.json
+++ b/config.json
@@ -1862,6 +1862,38 @@
         "https://raw.githubusercontent.com/tim-hub/tiny-cn-blocklist-replenish/master/others.txt"],
       "pack": ["liteprivacy", "gambling"],
       "level": [0, 1]
+    },
+    {
+      "vname": "fuckfuckadblock (pop-ups & anti-adblock bypass)",
+
+      "group": "ParentalControl",
+      "subg": "fuckfuckadblock",
+
+      "format": "abp",
+      "URL": [
+        "https://fuckfuckadblock.pages.dev/fuckfuckadblock.txt?_=3",
+        "https://raw.githack.com/bogachenko/fuckfuckadblock/master/fuckfuckadblock.txt?_=3",
+        "https://cdn.statically.io/gh/bogachenko/fuckfuckadblock/master/fuckfuckadblock.txt?_=3",
+        "https://raw.githubusercontent.com/bogachenko/fuckfuckadblock/master/fuckfuckadblock.txt?_=3"],
+
+      "pack": ["recommended", "spam"],
+      "level": [2, 2]
+    },
+    {
+      "vname": "fuckfuckadblock (mining)",
+
+      "group": "ParentalControl",
+      "subg": "fuckfuckadblock",
+
+      "format": "abp",
+      "URL": [
+        "https://fuckfuckadblock.pages.dev/fuckfuckadblock-mining.txt?_=3",
+        "https://raw.githack.com/bogachenko/fuckfuckadblock/master/fuckfuckadblock-mining.txt?_=3",
+        "https://cdn.statically.io/gh/bogachenko/fuckfuckadblock/master/fuckfuckadblock-mining.txt?_=3",
+        "https://raw.githubusercontent.com/bogachenko/fuckfuckadblock/master/fuckfuckadblock-mining.txt?_=3"],
+
+      "pack": ["recommended", "spyware", "malware", "scams & phishing"],
+      "level": [2, 2, 2, 2]
     }
   ]
 }


### PR DESCRIPTION
Added Apple Block Certificate Revoke + OTA, source is from [Nguyenhuyhoang](https://github.com/Nguyenhuyhoan/Config)
This help prevent Apple from revoking certificate and block OTA update (I think so)