### PR TITLE
Jarelllama's Scam Blocklist

### DIFF
--- a/config.json
+++ b/config.json
@@ -1863,6 +1863,18 @@
         "https://raw.githubusercontent.com/tim-hub/tiny-cn-blocklist-replenish/master/others.txt"],
       "pack": ["liteprivacy", "gambling"],
       "level": [0, 1]
+    },
+    {
+      "vname": "Jarelllama's Scam Blocklist",
+
+      "group": "Security",
+      "subg": "",
+
+      "format": "abp",
+      "url": "https://raw.githubusercontent.com/jarelllama/Scam-Blocklist/main/lists/adblock/scams.txt",
+
+      "pack": ["scams & phishing"],
+      "level": [1]
     }
   ]
 }

--- a/config.json
+++ b/config.json
@@ -1868,7 +1868,7 @@
       "vname": "Jarelllama's Scam Blocklist",
 
       "group": "Security",
-      "subg": "",
+      "subg": "Scam Blocklist",
 
       "format": "abp",
       "url": "https://raw.githubusercontent.com/jarelllama/Scam-Blocklist/main/lists/adblock/scams.txt",


### PR DESCRIPTION
Blocklist for newly created scam and phishing domains automatically retrieved daily using Google Search API, automated NRD detection, and other public sources.

The blocklist aims to be an alternative to blocking all newly registered domains (NRDs) seeing how many, but not all, NRDs are malicious. A variety of sources are integrated to detect new malicious domains within a short time span of their registration date.

https://github.com/jarelllama/Scam-Blocklist

Currently integrated into Hagezi's TIF blocklist and the oisd blocklist.