### PR TITLE
Add FMHY Unsafe sites Filterlist

### DIFF
--- a/config.json
+++ b/config.json
@@ -578,18 +578,6 @@
       "level": [1]
     },
     {
-      "vname": "FMHY Unsafe sites",
-
-      "group": "Security",
-      "subg": "FMHY",
-
-      "format": "domains",
-      "url": "https://raw.githubusercontent.com/WindowsAurora/FMHYFilterlist/main/filterlist-domains.txt",
-
-      "pack": ["malware", "spyware"],
-      "level": [0, 1]
-    },
-    {
       "vname": "NoTrack Annoyance",
       "group": "Security",
       "subg": "Quidsup",
@@ -801,7 +789,7 @@
       "vname": "NSO + Others (Amnesty)",
       "group": "Security",
       "subg": "Amnesty",
-      "format": ["domains", "domains", "domains", "hosts", "domains", "domains", "domains"],
+      "format": ["domains", "domains", "domains", "hosts", "domains", "domains", "domains", "domains"],
       "url": [
         "https://raw.githubusercontent.com/AmnestyTech/investigations/master/2021-07-18_nso/domains.txt",
         "https://raw.githubusercontent.com/AmnestyTech/investigations/master/2021-10-07_donot/domains.txt",
@@ -809,7 +797,8 @@
         "https://raw.githubusercontent.com/cbuijs/accomplist/master/autodiscover/plain.black.domain.level-1.list",
         "https://raw.githubusercontent.com/scafroglia93/blocklists/master/blocklists-kaspersky.txt",
         "https://raw.githubusercontent.com/scafroglia93/blocklists/master/blocklists-zscaler.txt",
-        "https://raw.githubusercontent.com/scafroglia93/blocklists/master/blocklists-cyble.txt"],
+        "https://raw.githubusercontent.com/scafroglia93/blocklists/master/blocklists-cyble.txt",
+        "https://raw.githubusercontent.com/WindowsAurora/FMHYFilterlist/main/filterlist-domains.txt"],
       "pack": ["spyware", "malware"],
       "level": [0, 0]
     },

--- a/config.json
+++ b/config.json
@@ -798,7 +798,7 @@
         "https://raw.githubusercontent.com/scafroglia93/blocklists/master/blocklists-kaspersky.txt",
         "https://raw.githubusercontent.com/scafroglia93/blocklists/master/blocklists-zscaler.txt",
         "https://raw.githubusercontent.com/scafroglia93/blocklists/master/blocklists-cyble.txt",
-        "https://raw.githubusercontent.com/WindowsAurora/FMHYFilterlist/main/filterlist-domains.txt"],
+        "https://raw.githubusercontent.com/fmhy/FMHYFilterlist/main/filterlist-domains.txt"],
       "pack": ["spyware", "malware"],
       "level": [0, 0]
     },

--- a/config.json
+++ b/config.json
@@ -578,6 +578,18 @@
       "level": [1]
     },
     {
+      "vname": "FMHY Unsafe sites",
+
+      "group": "Security",
+      "subg": "FMHY",
+
+      "format": "domains",
+      "url": "https://raw.githubusercontent.com/WindowsAurora/FMHYFilterlist/main/filterlist-domains.txt",
+
+      "pack": ["malware", "spyware"],
+      "level": [0, 1]
+    },
+    {
       "vname": "NoTrack Annoyance",
       "group": "Security",
       "subg": "Quidsup",


### PR DESCRIPTION
This is blocklist for blocking mainly unsafe websites filled with malware downloads mostly related to piracy (but this blocklist is \*\*NOT\*\* intended to be used as "Anti piracy blocklist", this blocklist blocks just the dangerous domains), also it blocks domains of some (crappy) PUP softwares (thats why the "Spyware" pack has level "1", not "0" here, because some people with weird taste of software could use it and then complain, that it doesn‘t work right).
Reasons for blocking these domains can be found here: https://fmhy.net/unsafesites
Website of the blocklist: https://windowsaurora.github.io/FMHYFilterlist/site