### PR TITLE
config: Switch hole.cert.pl to v2 list and update categories

### DIFF
--- a/config.json
+++ b/config.json
@@ -889,8 +889,8 @@
       "group": "Security",
       "subg": "ThreatIntelligence",
       "format": "domains",
-      "url": "https://hole.cert.pl/domains/domains.txt",
-      "pack": ["malware"],
+      "url": "https://hole.cert.pl/domains/v2/domains.txt",
+      "pack": ["scams & phishing", "malware"],
       "level": [1]
     },
     {


### PR DESCRIPTION
https://cert.pl/en/warning-list/